### PR TITLE
Fix resource deprecation warning

### DIFF
--- a/_providers.tf
+++ b/_providers.tf
@@ -6,3 +6,7 @@ terraform {
     }
   }
 }
+
+provider "azurerm" {
+  features {}
+}

--- a/_variables.tf
+++ b/_variables.tf
@@ -1,13 +1,13 @@
 variable "workspace_name" {
   description = "The name of this Log Analytics workspace."
   type        = string
-  default     = "workspacename"
+  default     = "non-prod"
 }
 
 variable "resource_group_name" {
   description = "The name of the resource group to create the resources in."
   type        = string
-  default     = "rgname"
+  default     = "Ashwita"
 }
 
 variable "location" {

--- a/_variables.tf
+++ b/_variables.tf
@@ -1,13 +1,13 @@
 variable "workspace_name" {
   description = "The name of this Log Analytics workspace."
   type        = string
-  default     = "non-prod"
+  default     = ""
 }
 
 variable "resource_group_name" {
   description = "The name of the resource group to create the resources in."
   type        = string
-  default     = "Ashwita"
+  default     = ""
 }
 
 variable "location" {
@@ -23,6 +23,7 @@ variable "sku" {
 }
 
 variable "storage_account_id" {
+  description = "The ID of the Azure Storage account where diagnostic logs will be stored."
   type = string
   default = "subscriptions/75223151-1800-43db-a8f3-b7fe605d3385/resourceGroups/Ashwita/providers/Microsoft.Storage/storageAccounts/testinglogdiagnostic"
 }

--- a/_variables.tf
+++ b/_variables.tf
@@ -22,6 +22,11 @@ variable "sku" {
   default     = "PerGB2018"
 }
 
+variable "storage_account_id" {
+  type = string
+  default = "subscriptions/75223151-1800-43db-a8f3-b7fe605d3385/resourceGroups/Ashwita/providers/Microsoft.Storage/storageAccounts/testinglogdiagnostic"
+}
+
 variable "local_authentication_disabled" {
   description = "Specifies if the Log Analytics Workspace should enforce authentication using Azure AD."
   type        = bool

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -6,7 +6,7 @@ output "workspace_id" {
 
 output "workspace_customer_id" {
   description = "The workspace (customer) ID of this Log Analytics workspace."
-  value       = module.log_analytics.workspace_id.workspace_customer_id
+  value       = module.log_analytics.workspace_customer_id
   sensitive   = true
 }
 

--- a/log-analytics.tf
+++ b/log-analytics.tf
@@ -34,3 +34,51 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_settings" {
     }
   }
 }
+
+resource "azurerm_storage_management_policy" "example" {
+  storage_account_id = "subscriptions/75223151-1800-43db-a8f3-b7fe605d3385/resourceGroups/gaurav/providers/Microsoft.Storage/storageAccounts/terraformteststacc01"
+  // storage_account_id = azurerm_storage_account.example.id
+  rule {
+    name    = "rule1"
+    enabled = true
+    filters {
+      prefix_match = ["container1/prefix1"]
+      blob_types   = ["blockBlob"]
+    }
+    actions {
+      base_blob {
+        tier_to_cool_after_days_since_modification_greater_than    = 10
+        tier_to_archive_after_days_since_modification_greater_than = 50
+        delete_after_days_since_modification_greater_than          = 100
+      }
+      snapshot {
+        delete_after_days_since_creation_greater_than = 30
+      }
+    }
+  }
+  rule {
+    name    = "rule2"
+    enabled = false
+    filters {
+      prefix_match = ["container2/prefix1", "container2/prefix2"]
+      blob_types   = ["blockBlob"]
+    }
+    actions {
+      base_blob {
+        tier_to_cool_after_days_since_modification_greater_than    = 11
+        tier_to_archive_after_days_since_modification_greater_than = 51
+        delete_after_days_since_modification_greater_than          = 101
+      }
+      snapshot {
+        change_tier_to_archive_after_days_since_creation = 90
+        change_tier_to_cool_after_days_since_creation    = 23
+        delete_after_days_since_creation_greater_than    = 31
+      }
+      version {
+        change_tier_to_archive_after_days_since_creation = 9
+        change_tier_to_cool_after_days_since_creation    = 90
+        delete_after_days_since_creation                 = 3
+      }
+    }
+  }
+}

--- a/log-analytics.tf
+++ b/log-analytics.tf
@@ -33,6 +33,9 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_settings" {
       enabled  = metric.value.enabled
     }
   }
+
+    storage_account_id = "subscriptions/75223151-1800-43db-a8f3-b7fe605d3385/resourceGroups/gaurav/providers/Microsoft.Storage/storageAccounts/terraformteststacc01"
+
 }
 
 resource "azurerm_storage_management_policy" "example" {

--- a/log-analytics.tf
+++ b/log-analytics.tf
@@ -33,8 +33,7 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_settings" {
       enabled  = metric.value.enabled
     }
   }
-
-    storage_account_id = var.storage_account_id
+    //storage_account_id = var.storage_account_id
 }
 
 resource "azurerm_storage_management_policy" "example" {

--- a/log-analytics.tf
+++ b/log-analytics.tf
@@ -31,11 +31,6 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_settings" {
     content {
       category = metric.key
       enabled  = metric.value.enabled
-
-      retention_policy {
-        days    = metric.value.retention_days
-        enabled = metric.value.retention_enabled
-      }
     }
   }
 }

--- a/log-analytics.tf
+++ b/log-analytics.tf
@@ -34,12 +34,11 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_settings" {
     }
   }
 
-    storage_account_id = "subscriptions/75223151-1800-43db-a8f3-b7fe605d3385/resourceGroups/gaurav/providers/Microsoft.Storage/storageAccounts/terraformteststacc01"
-
+    storage_account_id = var.storage_account_id
 }
 
 resource "azurerm_storage_management_policy" "example" {
-  storage_account_id = "subscriptions/75223151-1800-43db-a8f3-b7fe605d3385/resourceGroups/gaurav/providers/Microsoft.Storage/storageAccounts/terraformteststacc01"
+    storage_account_id = var.storage_account_id
   // storage_account_id = azurerm_storage_account.example.id
   rule {
     name    = "rule1"


### PR DESCRIPTION
- **azurerm_monitor_diagnostic_setting** resource showing the warning of deprecation.
- It showing **retention_policy** has been deprecated in favor of **azurerm_storage_management_policy resource**.
- Retention policy is now removed and replaced by azurerm_storage_management_policy resource.
- It is working now properly.